### PR TITLE
feat: print時にカーソルを消すように実装

### DIFF
--- a/includes/data.h
+++ b/includes/data.h
@@ -14,6 +14,8 @@ TOP_LEFTは標準出力の位置を固定するためのものです
 これを出力の最初に行うことで、標準出力を使ったアニメーションができます
 */
 # define TOP_LEFT "\x1b[H"
+# define DISABLE_CURSOR "\033[?25l"
+# define ENABLE_CURSOR "\033[?25h"
 /*
 最大制度 DBL_EPSILON
 kawadaさんがEPSILONは 0.000001 くらいがいいって言ってた

--- a/srcs/draw.c
+++ b/srcs/draw.c
@@ -37,6 +37,7 @@ static void	draw_screen(t_data *data)
 
 	setbuf(stdout, buf);
 	printf(TOP_LEFT);
+	printf(DISABLE_CURSOR);
 	y = 0;
 	while (y <= HEIGHT)
 	{


### PR DESCRIPTION
シグナル終了したときに、カーソルが消えたままになるけど、優先順位を考えて、それは別ブランチで対応することにする。