### PR TITLE
getchのエラー処理

### DIFF
--- a/includes/control.h
+++ b/includes/control.h
@@ -8,7 +8,6 @@
 # include <stdio.h>
 # include <termios.h>
 # include <unistd.h>
-# include <fcntl.h>
 # include <stdlib.h>
 
 # define MOVE_SCALE 5

--- a/srcs/control/control5.c
+++ b/srcs/control/control5.c
@@ -28,11 +28,19 @@ void	print_info(t_data *data)
 	if (flg)
 	{
 		printf(WHITE"\n\
-======================================================\n\
-[Move camera] w s a d    [Rotate camera] i k j l m n  \n\
-[Move light] f t g h y u [Change color] 1 2 3 4 5 6 7 \n\
-[Zoom] z x [Pause] space [Reset] r [Quit] q           \n\
-======================================================\n");
+==================================================\
+===========================\n\
+[Move Camera]   Up: w Down: s Left: a Right: d\n\
+[Rotate Camera] Up: i Down: k Left: j Right: l \
+SppedUp: m SpeedDown: n\n\
+[Set Light]     Up: t Down: g Left: f Right: h \
+Front: y Back: u\n\
+[Change Color]  Red: 1 Blue: 2 Green: 3 Yellow: 4 \
+Magenta: 5 Cyan: 6 White: 7\n\
+[Zoom] In: z Out: x    [Pause/Resume] space    \
+[Reset] r    [Quit] q\n\
+==================================================\
+===========================\n");
 		printf("%s", data->config.color);
 		flg = false;
 	}

--- a/srcs/control/getch.c
+++ b/srcs/control/getch.c
@@ -1,4 +1,28 @@
+#include <fcntl.h>
+
 #include "control.h"
+
+int	fcntl_wrapper(int fd, int cmd, int arg)
+{
+	int ret;
+
+	ret = fcntl(fd, cmd, arg);
+	if (ret == -1)
+		exit_error("fcntl");
+	return (ret);
+}
+
+void	tcgetattr_wrapper(int fd, struct termios *termios)
+{
+	if (tcgetattr(fd, termios) == -1)
+		exit_error("tcgetattr");
+}
+
+void	tcsetattr_wrapper(int fd, int cmd, struct termios *termios)
+{
+	if (tcsetattr(fd, cmd, termios) == -1)
+		exit_error("tcsetattr");
+}
 
 int	getch(void)
 {
@@ -10,11 +34,11 @@ int	getch(void)
 	tcgetattr(STDIN_FILENO, &oldattr);
 	newattr = oldattr;
 	newattr.c_lflag &= ~(ICANON | ECHO);
-	tcsetattr(STDIN_FILENO, TCSANOW, &newattr);
-	old = fcntl(STDIN_FILENO, F_GETFL, 0);
-	fcntl(STDIN_FILENO, F_SETFL, old | O_NONBLOCK);
+	tcsetattr_wrapper(STDIN_FILENO, TCSANOW, &newattr);
+	old = fcntl_wrapper(STDIN_FILENO, F_GETFL, 0);
+	fcntl_wrapper(STDIN_FILENO, F_SETFL, old | O_NONBLOCK);
 	ch = getchar();
-	tcsetattr(STDIN_FILENO, TCSANOW, &oldattr);
-	fcntl(STDIN_FILENO, F_SETFL, old);
+	tcsetattr_wrapper(STDIN_FILENO, TCSANOW, &oldattr);
+	fcntl_wrapper(STDIN_FILENO, F_SETFL, old);
 	return (ch);
 }

--- a/srcs/control/getch.c
+++ b/srcs/control/getch.c
@@ -4,7 +4,7 @@
 
 int	fcntl_wrapper(int fd, int cmd, int arg)
 {
-	int ret;
+	int	ret;
 
 	ret = fcntl(fd, cmd, arg);
 	if (ret == -1)


### PR DESCRIPTION
errnoをチェックすると
Resource temporarily unavailable
と表示されてエラー終了してしまうため、返り値のチェックのみを行っています。